### PR TITLE
feat(rocketpack): add #[rust::derive(...)] attribute for struct/enum

### DIFF
--- a/entrypoints/rocketpack-compiler/src/codegen/rust.rs
+++ b/entrypoints/rocketpack-compiler/src/codegen/rust.rs
@@ -129,7 +129,11 @@ fn parse_sources(sources: &[DiscoveredSource]) -> Result<Vec<ParsedSource>, Code
     for source in sources {
         let text = fs::read_to_string(&source.absolute_path)?;
         let file = parser::parse_source(&source.absolute_path, &text)?;
-        parsed_sources.push(ParsedSource { source: source.clone(), file, text });
+        parsed_sources.push(ParsedSource {
+            source: source.clone(),
+            file,
+            text,
+        });
     }
 
     Ok(parsed_sources)
@@ -569,18 +573,7 @@ const DEFAULT_RUST_DERIVES: &[&str] = &["Debug", "Clone", "PartialEq"];
 
 /// `#[rust::derive(...)]` で追加指定できるトレイトの allowlist。
 /// スキーマコンパイル時点でタイポや未知のトレイトを検出するために使う。
-const ALLOWED_RUST_DERIVES: &[&str] = &[
-    "Copy",
-    "Debug",
-    "Default",
-    "Eq",
-    "Hash",
-    "Ord",
-    "PartialEq",
-    "PartialOrd",
-    "Serialize",
-    "Deserialize",
-];
+const ALLOWED_RUST_DERIVES: &[&str] = &["Copy", "Debug", "Default", "Eq", "Hash", "Ord", "PartialEq", "PartialOrd", "Serialize", "Deserialize"];
 
 /// `#[rust::derive(...)]` attribute で追加指定されたトレイトを
 /// デフォルトの derive リスト (`DEFAULT_RUST_DERIVES`) へ追記する。
@@ -616,11 +609,7 @@ fn render_rust_derive_line(parsed_source: &ParsedSource, attributes: &[Attribute
     if let Some(attr) = rust_derive_attr {
         for arg in &attr.args {
             if !ALLOWED_RUST_DERIVES.contains(&arg.value.as_str()) {
-                return Err(attribute_error(
-                    parsed_source,
-                    arg.span.clone(),
-                    "unexpected derive trait: not in the allowlist",
-                ));
+                return Err(attribute_error(parsed_source, arg.span.clone(), "unexpected derive trait: not in the allowlist"));
             }
             if !derives.iter().any(|d| d == &arg.value) {
                 derives.push(arg.value.clone());
@@ -635,11 +624,7 @@ fn render_rust_derive_line(parsed_source: &ParsedSource, attributes: &[Attribute
 /// item_name はエラー文に含めず、span が示す位置とソース行 (caret) で該当箇所を特定する。
 fn attribute_error(parsed_source: &ParsedSource, span: Span, message: &'static str) -> CodegenError {
     let error = ParseError::new(ParseErrorKind::Unexpected(message), span.start, span.end);
-    CodegenError::Parse(ParseErrorBundle::new(
-        parsed_source.source.absolute_path.clone(),
-        parsed_source.text.clone(),
-        vec![error],
-    ))
+    CodegenError::Parse(ParseErrorBundle::new(parsed_source.source.absolute_path.clone(), parsed_source.text.clone(), vec![error]))
 }
 
 fn write_struct_declaration(out: &mut String, parsed_source: &ParsedSource, index: &SchemaIndex, item: &Struct, depth: usize) -> Result<(), CodegenError> {

--- a/entrypoints/rocketpack-compiler/src/codegen/rust.rs
+++ b/entrypoints/rocketpack-compiler/src/codegen/rust.rs
@@ -13,7 +13,7 @@ use crate::{
     error::CodegenError,
     parser::{
         self,
-        ast::{Const, Enum, Field, File, Item, LengthBound, LengthRange, Literal, Path as AstPath, Struct, Type, VariantKind},
+        ast::{Attribute, Const, Enum, Field, File, Item, LengthBound, LengthRange, Literal, Path as AstPath, Struct, Type, VariantKind},
     },
 };
 
@@ -541,12 +541,12 @@ fn render_rust_file(parsed_source: &ParsedSource, index: &SchemaIndex) -> Result
     for item in &parsed_source.file.items {
         match item {
             Item::Struct(item) => {
-                write_struct_declaration(&mut out, index, item, depth);
+                write_struct_declaration(&mut out, index, item, depth)?;
                 writeln!(&mut out).ok();
                 write_struct_codec_impl(&mut out, index, item, depth)?;
             }
             Item::Enum(item) => {
-                write_enum_declaration(&mut out, index, item, depth);
+                write_enum_declaration(&mut out, index, item, depth)?;
                 writeln!(&mut out).ok();
                 write_enum_codec_impl(&mut out, index, item, depth)?;
             }
@@ -563,8 +563,36 @@ fn render_rust_file(parsed_source: &ParsedSource, index: &SchemaIndex) -> Result
     Ok(out)
 }
 
-fn write_struct_declaration(out: &mut String, index: &SchemaIndex, item: &Struct, depth: usize) {
-    writeln!(out, "{}#[derive(Debug, Clone, PartialEq)]", indent(depth)).ok();
+const DEFAULT_RUST_DERIVES: &[&str] = &["Debug", "Clone", "PartialEq"];
+
+/// `#[rust::derive(...)]` attribute で追加指定されたトレイトを
+/// デフォルトの derive リスト (`DEFAULT_RUST_DERIVES`) へ追記する。
+/// 実行可能性 (フィールド型が対応しているか) は検証せず、そのまま出力する。
+fn render_rust_derive_line(attributes: &[Attribute], item_name: &str) -> Result<String, CodegenError> {
+    let mut rust_derive_attrs = attributes.iter().filter(|attr| {
+        let segments = path_segments(&attr.path.value);
+        segments.len() == 2 && segments[0] == "rust" && segments[1] == "derive"
+    });
+
+    let mut derives: Vec<String> = DEFAULT_RUST_DERIVES.iter().map(|s| s.to_string()).collect();
+
+    if let Some(attr) = rust_derive_attrs.next() {
+        if rust_derive_attrs.next().is_some() {
+            return Err(CodegenError::Other(format!("duplicate #[rust::derive(...)] attribute on `{item_name}`")));
+        }
+
+        for arg in &attr.args {
+            if !derives.iter().any(|d| d == &arg.value) {
+                derives.push(arg.value.clone());
+            }
+        }
+    }
+
+    Ok(format!("#[derive({})]", derives.join(", ")))
+}
+
+fn write_struct_declaration(out: &mut String, index: &SchemaIndex, item: &Struct, depth: usize) -> Result<(), CodegenError> {
+    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(&item.attributes, &item.name.value)?).ok();
     writeln!(out, "{}pub struct {} {{", indent(depth), sanitize_ident(&item.name.value)).ok();
 
     for field in &item.fields {
@@ -579,6 +607,8 @@ fn write_struct_declaration(out: &mut String, index: &SchemaIndex, item: &Struct
     }
 
     writeln!(out, "{}}}", indent(depth)).ok();
+
+    Ok(())
 }
 
 fn write_struct_codec_impl(out: &mut String, index: &SchemaIndex, item: &Struct, depth: usize) -> Result<(), CodegenError> {
@@ -1599,8 +1629,8 @@ fn declare_record_variant_storage(out: &mut String, index: &SchemaIndex, fields:
     }
 }
 
-fn write_enum_declaration(out: &mut String, index: &SchemaIndex, item: &Enum, depth: usize) {
-    writeln!(out, "{}#[derive(Debug, Clone, PartialEq)]", indent(depth)).ok();
+fn write_enum_declaration(out: &mut String, index: &SchemaIndex, item: &Enum, depth: usize) -> Result<(), CodegenError> {
+    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(&item.attributes, &item.name.value)?).ok();
     writeln!(out, "{}pub enum {} {{", indent(depth), sanitize_ident(&item.name.value)).ok();
 
     for variant in &item.variants {
@@ -1633,6 +1663,8 @@ fn write_enum_declaration(out: &mut String, index: &SchemaIndex, item: &Enum, de
     }
 
     writeln!(out, "{}}}", indent(depth)).ok();
+
+    Ok(())
 }
 
 fn write_type_alias_declaration(out: &mut String, index: &SchemaIndex, item: &crate::parser::ast::TypeAlias, depth: usize) {
@@ -1955,6 +1987,41 @@ mod tests {
             },
             file: parser::parse_source("test.rpf", source).expect("test schema must parse"),
         }
+    }
+
+    #[test]
+    fn appends_rust_derive_attribute_to_default_derives() {
+        let source = parsed_source(
+            "version 1; package test; #[rust::derive(Eq, Hash)] struct Sample { @1 value: string; } #[rust::derive(Eq, Hash)] enum Kind { @1 A; @2 B; } struct Plain { @1 value: u32; }",
+        );
+        let rendered = render_sources(&[source]).expect("valid schema must render")[0].contents.clone();
+
+        assert!(rendered.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]\n    pub struct Sample"));
+        assert!(rendered.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]\n    pub enum Kind"));
+        assert!(rendered.contains("#[derive(Debug, Clone, PartialEq)]\n    pub struct Plain"));
+    }
+
+    #[test]
+    fn dedupes_rust_derive_attribute_args_overlapping_defaults() {
+        let source = parsed_source("version 1; package test; #[rust::derive(PartialEq, Eq)] struct Sample { @1 value: string; }");
+        let rendered = render_sources(&[source]).expect("valid schema must render")[0].contents.clone();
+
+        assert!(rendered.contains("#[derive(Debug, Clone, PartialEq, Eq)]\n    pub struct Sample"));
+    }
+
+    #[test]
+    fn rejects_duplicate_rust_derive_attribute_on_same_item() {
+        let source = parsed_source("version 1; package test; #[rust::derive(Eq)] #[rust::derive(Hash)] struct Sample { @1 value: string; }");
+        let error = render_sources(&[source]).expect_err("duplicate rust::derive attribute must fail");
+        assert!(error.to_string().contains("duplicate #[rust::derive(...)] attribute on `Sample`"), "{error}");
+    }
+
+    #[test]
+    fn ignores_attributes_with_a_different_namespace() {
+        let source = parsed_source("version 1; package test; #[csharp::partial] struct Sample { @1 value: string; }");
+        let rendered = render_sources(&[source]).expect("unrelated namespace attribute must be ignored")[0].contents.clone();
+
+        assert!(rendered.contains("#[derive(Debug, Clone, PartialEq)]\n    pub struct Sample"));
     }
 
     #[test]

--- a/entrypoints/rocketpack-compiler/src/codegen/rust.rs
+++ b/entrypoints/rocketpack-compiler/src/codegen/rust.rs
@@ -10,10 +10,10 @@ use tracing::info;
 
 use crate::{
     config::{GeneratorConfig, GeneratorTargetConfig, SourceConfig},
-    error::CodegenError,
+    error::{CodegenError, ParseError, ParseErrorBundle, ParseErrorKind},
     parser::{
         self,
-        ast::{Attribute, Const, Enum, Field, File, Item, LengthBound, LengthRange, Literal, Path as AstPath, Struct, Type, VariantKind},
+        ast::{Attribute, Const, Enum, Field, File, Item, LengthBound, LengthRange, Literal, Path as AstPath, Span, Struct, Type, VariantKind},
     },
 };
 
@@ -28,6 +28,7 @@ struct DiscoveredSource {
 struct ParsedSource {
     source: DiscoveredSource,
     file: File,
+    text: String,
 }
 
 #[derive(Debug, Clone)]
@@ -126,8 +127,9 @@ fn parse_sources(sources: &[DiscoveredSource]) -> Result<Vec<ParsedSource>, Code
     let mut parsed_sources = Vec::with_capacity(sources.len());
 
     for source in sources {
-        let file = parser::parse(&source.absolute_path)?;
-        parsed_sources.push(ParsedSource { source: source.clone(), file });
+        let text = fs::read_to_string(&source.absolute_path)?;
+        let file = parser::parse_source(&source.absolute_path, &text)?;
+        parsed_sources.push(ParsedSource { source: source.clone(), file, text });
     }
 
     Ok(parsed_sources)
@@ -541,12 +543,12 @@ fn render_rust_file(parsed_source: &ParsedSource, index: &SchemaIndex) -> Result
     for item in &parsed_source.file.items {
         match item {
             Item::Struct(item) => {
-                write_struct_declaration(&mut out, index, item, depth)?;
+                write_struct_declaration(&mut out, parsed_source, index, item, depth)?;
                 writeln!(&mut out).ok();
                 write_struct_codec_impl(&mut out, index, item, depth)?;
             }
             Item::Enum(item) => {
-                write_enum_declaration(&mut out, index, item, depth)?;
+                write_enum_declaration(&mut out, parsed_source, index, item, depth)?;
                 writeln!(&mut out).ok();
                 write_enum_codec_impl(&mut out, index, item, depth)?;
             }
@@ -565,23 +567,61 @@ fn render_rust_file(parsed_source: &ParsedSource, index: &SchemaIndex) -> Result
 
 const DEFAULT_RUST_DERIVES: &[&str] = &["Debug", "Clone", "PartialEq"];
 
+/// `#[rust::derive(...)]` で追加指定できるトレイトの allowlist。
+/// スキーマコンパイル時点でタイポや未知のトレイトを検出するために使う。
+const ALLOWED_RUST_DERIVES: &[&str] = &[
+    "Copy",
+    "Debug",
+    "Default",
+    "Eq",
+    "Hash",
+    "Ord",
+    "PartialEq",
+    "PartialOrd",
+    "Serialize",
+    "Deserialize",
+];
+
 /// `#[rust::derive(...)]` attribute で追加指定されたトレイトを
 /// デフォルトの derive リスト (`DEFAULT_RUST_DERIVES`) へ追記する。
-/// 実行可能性 (フィールド型が対応しているか) は検証せず、そのまま出力する。
-fn render_rust_derive_line(attributes: &[Attribute], item_name: &str) -> Result<String, CodegenError> {
-    let mut rust_derive_attrs = attributes.iter().filter(|attr| {
+/// トレイト名は `ALLOWED_RUST_DERIVES` で検証し、`rust::` 配下の未知アトリビュート
+/// や重複した `#[rust::derive(...)]` は `ParseErrorKind::Unexpected` の parse error にする。
+/// フィールド型がそのトレイトを実装できるか (実行可能性) は検証せず、そのまま出力する。
+fn render_rust_derive_line(parsed_source: &ParsedSource, attributes: &[Attribute]) -> Result<String, CodegenError> {
+    let mut rust_derive_attr: Option<&Attribute> = None;
+    for attr in attributes {
         let segments = path_segments(&attr.path.value);
-        segments.len() == 2 && segments[0] == "rust" && segments[1] == "derive"
-    });
+        if segments.len() == 2 && segments[0] == "rust" {
+            if segments[1] != "derive" {
+                return Err(attribute_error(
+                    parsed_source,
+                    attr.path.span.clone(),
+                    "unexpected attribute: only `rust::derive` is supported under the `rust::` namespace",
+                ));
+            }
+            if rust_derive_attr.is_some() {
+                return Err(attribute_error(
+                    parsed_source,
+                    attr.path.span.clone(),
+                    "unexpected attribute: duplicate `#[rust::derive(...)]`",
+                ));
+            }
+            rust_derive_attr = Some(attr);
+        }
+        // 他 namespace (例: `csharp::partial`) はこのジェネレータでは無視する。
+    }
 
     let mut derives: Vec<String> = DEFAULT_RUST_DERIVES.iter().map(|s| s.to_string()).collect();
 
-    if let Some(attr) = rust_derive_attrs.next() {
-        if rust_derive_attrs.next().is_some() {
-            return Err(CodegenError::Other(format!("duplicate #[rust::derive(...)] attribute on `{item_name}`")));
-        }
-
+    if let Some(attr) = rust_derive_attr {
         for arg in &attr.args {
+            if !ALLOWED_RUST_DERIVES.contains(&arg.value.as_str()) {
+                return Err(attribute_error(
+                    parsed_source,
+                    arg.span.clone(),
+                    "unexpected derive trait: not in the allowlist",
+                ));
+            }
             if !derives.iter().any(|d| d == &arg.value) {
                 derives.push(arg.value.clone());
             }
@@ -591,8 +631,19 @@ fn render_rust_derive_line(attributes: &[Attribute], item_name: &str) -> Result<
     Ok(format!("#[derive({})]", derives.join(", ")))
 }
 
-fn write_struct_declaration(out: &mut String, index: &SchemaIndex, item: &Struct, depth: usize) -> Result<(), CodegenError> {
-    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(&item.attributes, &item.name.value)?).ok();
+/// アトリビュートの検証エラーを parse error (`ParseErrorKind::Unexpected`) として返す。
+/// item_name はエラー文に含めず、span が示す位置とソース行 (caret) で該当箇所を特定する。
+fn attribute_error(parsed_source: &ParsedSource, span: Span, message: &'static str) -> CodegenError {
+    let error = ParseError::new(ParseErrorKind::Unexpected(message), span.start, span.end);
+    CodegenError::Parse(ParseErrorBundle::new(
+        parsed_source.source.absolute_path.clone(),
+        parsed_source.text.clone(),
+        vec![error],
+    ))
+}
+
+fn write_struct_declaration(out: &mut String, parsed_source: &ParsedSource, index: &SchemaIndex, item: &Struct, depth: usize) -> Result<(), CodegenError> {
+    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(parsed_source, &item.attributes)?).ok();
     writeln!(out, "{}pub struct {} {{", indent(depth), sanitize_ident(&item.name.value)).ok();
 
     for field in &item.fields {
@@ -1629,8 +1680,8 @@ fn declare_record_variant_storage(out: &mut String, index: &SchemaIndex, fields:
     }
 }
 
-fn write_enum_declaration(out: &mut String, index: &SchemaIndex, item: &Enum, depth: usize) -> Result<(), CodegenError> {
-    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(&item.attributes, &item.name.value)?).ok();
+fn write_enum_declaration(out: &mut String, parsed_source: &ParsedSource, index: &SchemaIndex, item: &Enum, depth: usize) -> Result<(), CodegenError> {
+    writeln!(out, "{}{}", indent(depth), render_rust_derive_line(parsed_source, &item.attributes)?).ok();
     writeln!(out, "{}pub enum {} {{", indent(depth), sanitize_ident(&item.name.value)).ok();
 
     for variant in &item.variants {
@@ -1986,6 +2037,7 @@ mod tests {
                 relative_path: PathBuf::from("test.rpf"),
             },
             file: parser::parse_source("test.rpf", source).expect("test schema must parse"),
+            text: source.to_string(),
         }
     }
 
@@ -2013,7 +2065,21 @@ mod tests {
     fn rejects_duplicate_rust_derive_attribute_on_same_item() {
         let source = parsed_source("version 1; package test; #[rust::derive(Eq)] #[rust::derive(Hash)] struct Sample { @1 value: string; }");
         let error = render_sources(&[source]).expect_err("duplicate rust::derive attribute must fail");
-        assert!(error.to_string().contains("duplicate #[rust::derive(...)] attribute on `Sample`"), "{error}");
+        assert!(error.to_string().contains("duplicate `#[rust::derive(...)]`"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unknown_rust_attribute() {
+        let source = parsed_source("version 1; package test; #[rust::partial] struct Sample { @1 value: string; }");
+        let error = render_sources(&[source]).expect_err("unsupported rust:: attribute must fail");
+        assert!(error.to_string().contains("only `rust::derive` is supported"), "{error}");
+    }
+
+    #[test]
+    fn rejects_derive_trait_outside_the_allowlist() {
+        let source = parsed_source("version 1; package test; #[rust::derive(PartialEq, TotallyMadeUp)] struct Sample { @1 value: string; }");
+        let error = render_sources(&[source]).expect_err("unknown derive trait must fail");
+        assert!(error.to_string().contains("unexpected derive trait: not in the allowlist"), "{error}");
     }
 
     #[test]

--- a/entrypoints/rocketpack-compiler/src/error.rs
+++ b/entrypoints/rocketpack-compiler/src/error.rs
@@ -108,9 +108,6 @@ pub enum ParseErrorKind {
 
     #[error("duplicate attribute or item")]
     Duplicate,
-
-    #[error("other error: {0}")]
-    Other(String),
 }
 
 #[derive(Error, Debug)]

--- a/entrypoints/rocketpack-compiler/src/parser.rs
+++ b/entrypoints/rocketpack-compiler/src/parser.rs
@@ -88,6 +88,7 @@ impl Parser {
             Some(Token::Str(_)) => "string",
             Some(Token::Bytes(_)) => "bytes",
             Some(Token::At) => "@",
+            Some(Token::Hash) => "#",
             Some(Token::Semi) => ";",
             Some(Token::Colon) => ":",
             Some(Token::Comma) => ",",
@@ -119,6 +120,26 @@ impl Parser {
 
         // 任意の順序でトップレベルを読み込む
         while let Some(_) = self.peek() {
+            if self.at(Token::Hash) {
+                let attributes = self.parse_attributes();
+                match self.peek_keyword().as_deref() {
+                    Some("struct") => {
+                        let mut s = self.parse_struct();
+                        s.attributes = attributes;
+                        file.items.push(Item::Struct(s));
+                    }
+                    Some("enum") => {
+                        let mut e = self.parse_enum();
+                        e.attributes = attributes;
+                        file.items.push(Item::Enum(e));
+                    }
+                    _ => {
+                        self.error_here(ParseErrorKind::Unexpected("attributes are only allowed on struct/enum"));
+                    }
+                }
+                continue;
+            }
+
             // キーワードは Ident で来るので先読みして判定
             if let Some(kw) = self.peek_keyword() {
                 match kw.as_str() {
@@ -180,6 +201,39 @@ impl Parser {
         }
     }
 
+    // ===== attribute =====
+
+    fn parse_attributes(&mut self) -> Vec<Attribute> {
+        let mut attributes = Vec::new();
+        while self.at(Token::Hash) {
+            attributes.push(self.parse_attribute());
+        }
+        attributes
+    }
+
+    fn parse_attribute(&mut self) -> Attribute {
+        self.expect(Token::Hash, "#");
+        self.expect(Token::LBracket, "[");
+        let path = Spanned::new(self.parse_path(), self.prev_start(), self.prev_end());
+
+        let mut args = Vec::new();
+        if self.at(Token::LParen) {
+            self.bump();
+            while !self.at(Token::RParen) && self.peek().is_some() {
+                args.push(self.expect_ident());
+                if self.at(Token::Comma) {
+                    self.bump();
+                } else {
+                    break;
+                }
+            }
+            self.expect(Token::RParen, ")");
+        }
+
+        self.expect(Token::RBracket, "]");
+        Attribute { path, args }
+    }
+
     // ===== トップレベル要素 =====
 
     fn parse_version(&mut self) -> Spanned<u32> {
@@ -224,7 +278,11 @@ impl Parser {
             }
         }
         self.expect(Token::RBrace, "}");
-        Struct { name, fields }
+        Struct {
+            name,
+            fields,
+            attributes: Vec::new(),
+        }
     }
 
     fn parse_enum(&mut self) -> Enum {
@@ -241,7 +299,11 @@ impl Parser {
             }
         }
         self.expect(Token::RBrace, "}");
-        Enum { name, variants }
+        Enum {
+            name,
+            variants,
+            attributes: Vec::new(),
+        }
     }
 
     fn parse_type_alias(&mut self) -> TypeAlias {
@@ -430,6 +492,7 @@ impl Parser {
             Token::Str(_) => "string",
             Token::Bytes(_) => "bytes",
             Token::At => "@",
+            Token::Hash => "#",
             Token::Semi => ";",
             Token::Colon => ":",
             Token::Comma => ",",

--- a/entrypoints/rocketpack-compiler/src/parser.rs
+++ b/entrypoints/rocketpack-compiler/src/parser.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::{
     error::{ParseError, ParseErrorBundle, ParseErrorKind},
@@ -7,18 +7,6 @@ use crate::{
 
 pub mod ast;
 pub mod lexer;
-
-pub fn parse(path: &std::path::Path) -> Result<File, ParseErrorBundle> {
-    let source = fs::read_to_string(path).map_err(|err| {
-        ParseErrorBundle::new(
-            path,
-            String::new(),
-            vec![ParseError::new(ParseErrorKind::Other(format!("failed to read file: {err}")), 0, 0)],
-        )
-    })?;
-
-    parse_source(path.to_path_buf(), &source)
-}
 
 pub fn parse_source(path: impl Into<PathBuf>, source: &str) -> Result<File, ParseErrorBundle> {
     let path = path.into();
@@ -214,7 +202,10 @@ impl Parser {
     fn parse_attribute(&mut self) -> Attribute {
         self.expect(Token::Hash, "#");
         self.expect(Token::LBracket, "[");
-        let path = Spanned::new(self.parse_path(), self.prev_start(), self.prev_end());
+        let path_start = self.peek().map(|t| t.span.start).unwrap_or(self.prev_end());
+        let path = self.parse_path();
+        let path_end = self.prev_end();
+        let path = Spanned::new(path, path_start, path_end);
 
         let mut args = Vec::new();
         if self.at(Token::LParen) {

--- a/entrypoints/rocketpack-compiler/src/parser/ast.rs
+++ b/entrypoints/rocketpack-compiler/src/parser/ast.rs
@@ -32,6 +32,18 @@ pub struct Use {
     pub alias: Option<Spanned<String>>,
 }
 
+// ===== attribute =====
+//
+// `#[namespace::name(arg1, arg2, ...)]` を struct/enum の直前に書く。
+// namespace はコード生成ターゲット (例: `rust`) を表し、自分のnamespaceと一致しない
+// attribute は各ジェネレータが無視する。
+
+#[derive(Debug, Clone)]
+pub struct Attribute {
+    pub path: Spanned<Path>,
+    pub args: Vec<Spanned<String>>,
+}
+
 #[derive(Debug, Clone)]
 pub enum Item {
     Struct(Struct),
@@ -95,6 +107,7 @@ pub enum Literal {
 pub struct Struct {
     pub name: Spanned<String>,
     pub fields: Vec<Field>,
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +124,7 @@ pub struct Field {
 pub struct Enum {
     pub name: Spanned<String>,
     pub variants: Vec<Variant>,
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(Debug, Clone)]

--- a/entrypoints/rocketpack-compiler/src/parser/lexer.rs
+++ b/entrypoints/rocketpack-compiler/src/parser/lexer.rs
@@ -13,6 +13,8 @@ pub enum Token {
     // Separators / punctuation
     #[token("@")]
     At,
+    #[token("#")]
+    Hash,
     #[token(";")]
     Semi,
     #[token(":")]


### PR DESCRIPTION
## 概要

rocketpack スキーマ言語の struct / enum に `#[rust::derive(...)]` 属性を指定できるようにし、Rust コード生成時の `derive` リストを拡張できるようにします。

## 変更内容

- **lexer / parser / AST**: `#` トークンの追加と `#[namespace::name(args...)]` 形式の attribute のパース
  - namespace は生成ターゲット（例: `rust`）を表し、一致しない namespace の attribute は各ジェネレータが無視する設計
  - attribute は struct / enum にのみ許可（それ以外の位置ではパースエラー）
- **Rust codegen**: デフォルトの `#[derive(Debug, Clone, PartialEq)]` に対して `#[rust::derive(...)]` で指定されたトレイトを追加
  - デフォルトと重複する引数は dedupe
  - 同一アイテムへの `rust::derive` の重複指定はエラー
  - 実行可能性（フィールド型が derive に対応しているか）は検証せず、そのまま出力

## 例

```text
version 1;
package test;

#[rust::derive(Eq, Hash)]
struct Sample {
    @1 value: string;
}
```

→ 生成される Rust:

```rust
#[derive(Debug, Clone, PartialEq, Eq, Hash)]
pub struct Sample { ... }
```

## テスト

- デフォルト derive への追記
- デフォルトと重複する引数の dedupe
- 同一アイテムへの重複 attribute のエラー
- 別 namespace の attribute の無視