### PR TITLE
fix(migration): apply each migration file atomically

### DIFF
--- a/modules/migration/src/postgres.rs
+++ b/modules/migration/src/postgres.rs
@@ -32,7 +32,7 @@ impl PostgresMigrator {
         })
     }
 
-    pub async fn migrate(&self) -> Result<()> {
+    pub async fn migrate(&mut self) -> Result<()> {
         self.init().await?;
 
         let histories: Vec<MigrationHistory> = self.get_migration_histories().await?;
@@ -115,21 +115,23 @@ SELECT file_name, executed_at FROM _migrations
         Ok(results)
     }
 
-    async fn execute_migration_queries(&self, files: Vec<MigrationFile>) -> Result<()> {
+    async fn execute_migration_queries(&mut self, files: Vec<MigrationFile>) -> Result<()> {
         for f in files {
-            self.client.batch_execute(&f.queries).await?;
-            self.insert_migration_history(&f.file_name, &f.queries).await?;
+            let tx = self.client.transaction().await?;
+            tx.batch_execute(&f.queries).await?;
+            Self::insert_migration_history(&tx, &f.file_name, &f.queries).await?;
+            tx.commit().await?;
             info!(file_name = f.file_name, "processed migration file")
         }
 
         Ok(())
     }
 
-    async fn insert_migration_history(&self, file_name: &str, queries: &str) -> Result<()> {
+    async fn insert_migration_history(tx: &tokio_postgres::Transaction<'_>, file_name: &str, queries: &str) -> Result<()> {
         let statement = "\
 INSERT INTO _migrations (file_name, queries) VALUES ($1, $2)
 ";
-        self.client.execute(statement, &[&file_name, &queries]).await?;
+        tx.execute(statement, &[&file_name, &queries]).await?;
 
         Ok(())
     }

--- a/modules/migration/src/sqlite.rs
+++ b/modules/migration/src/sqlite.rs
@@ -56,21 +56,25 @@ SELECT name, executed_at FROM _migrations
 
     async fn execute_migration_queries(db: &SqlitePool, requests: Vec<MigrationRequest>) -> Result<()> {
         for r in requests {
+            let mut tx = db.begin().await?;
+
             for query in r.queries.split(';') {
                 let query = query.trim();
                 if query.is_empty() {
                     continue;
                 }
-                sqlx::query(sqlx::AssertSqlSafe(query)).execute(db).await?;
+                sqlx::query(sqlx::AssertSqlSafe(query)).execute(&mut *tx).await?;
             }
 
-            Self::insert_migration_history(db, r.name.as_str(), r.queries.as_str()).await?;
+            Self::insert_migration_history(&mut tx, r.name.as_str(), r.queries.as_str()).await?;
+
+            tx.commit().await?;
         }
 
         Ok(())
     }
 
-    async fn insert_migration_history(db: &SqlitePool, name: &str, queries: &str) -> Result<()> {
+    async fn insert_migration_history(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, name: &str, queries: &str) -> Result<()> {
         sqlx::query(
             r#"
 INSERT INTO _migrations (name, queries) VALUES ($1, $2)
@@ -78,7 +82,7 @@ INSERT INTO _migrations (name, queries) VALUES ($1, $2)
         )
         .bind(name)
         .bind(queries)
-        .execute(db)
+        .execute(&mut **tx)
         .await?;
 
         Ok(())

--- a/modules/migration/tests/postgres.rs
+++ b/modules/migration/tests/postgres.rs
@@ -12,7 +12,7 @@ mod tests {
     async fn simple_create_table_test() -> TestResult {
         let container = PostgresContainer::new(POSTGRES_VERSION).await?;
 
-        let migrator = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
+        let mut migrator = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
 
         migrator.migrate().await?;
 
@@ -24,7 +24,7 @@ mod tests {
     async fn create_table_syntax_error_test() -> TestResult {
         let container = PostgresContainer::new(POSTGRES_VERSION).await?;
 
-        let migrator = PostgresMigrator::new(&container.connection_string, "./tests/cases/create_table_syntax_error", "test01", "test01_description").await?;
+        let mut migrator = PostgresMigrator::new(&container.connection_string, "./tests/cases/create_table_syntax_error", "test01", "test01_description").await?;
 
         assert!(migrator.migrate().await.is_err());
 
@@ -36,11 +36,11 @@ mod tests {
     async fn migrate_twice_test() -> TestResult {
         let container = PostgresContainer::new(POSTGRES_VERSION).await?;
 
-        let migrator1 = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
+        let mut migrator1 = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
 
         migrator1.migrate().await?;
 
-        let migrator2 = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
+        let mut migrator2 = PostgresMigrator::new(&container.connection_string, "./tests/cases/simple_create_table", "test01", "test01_description").await?;
 
         migrator2.migrate().await?;
 


### PR DESCRIPTION
## 背景と目的

PostgreSQL と SQLite の migrator は、migration file 内のクエリまたは履歴の記録に失敗しても、先行クエリの適用結果を残していた。
schema と `_migrations` の履歴を一致させ、失敗した migration file を再実行可能にする。

## 概要

migration file ごとにクエリ実行と履歴記録を同一 transaction に入れ、両方が成功した場合だけ commit する。

## 影響範囲

- PostgreSQL と SQLite の `migrate` 呼び出しは、1 migration file を原子的に適用する。
- PostgreSQL の `PostgresMigrator::migrate` は transaction を開始するため `&mut self` を受け取る。呼び出し側は migrator を可変束縛にする必要がある。
- migration のファイル形式、履歴テーブルの schema、CLI・設定の外部契約は変更しない。
- デプロイ手順や既存 database の migration は不要であり、失敗済みの migration は従来どおり原因を直してから再実行する。

## 変更の全体構造

最初に `modules/migration/src/postgres.rs` を読むと、file 単位の transaction 境界と履歴記録の位置が分かる。
SQLite 側にも同じ不変条件を適用し、PostgreSQL 統合テストの可変借用を API 変更に合わせる。

## 検証したこと

自動検証は GitHub Actions の [`test-slim` run 31797993452](https://github.com/omnius-labs/core-rs/actions/runs/31797993452) で `cargo make lint` と `cargo test` を Ubuntu、Windows、macOS で実行した。
3 環境のすべての job が成功した。

既存の PostgreSQL 構文エラー migration test が `migrate()` の失敗を返す経路も、CI の `cargo test` に含めて確認した。

## レビューしてほしい観点

- transaction の境界が migration file と履歴記録を過不足なく覆い、部分適用を残さないか。
- `PostgresMigrator::migrate(&mut self)` への API 変更が transaction API の制約に対して妥当か。
- SQLite 側でもクエリ実行と履歴記録が同じ transaction executor を使っているか。

## 非目標

- 既に部分適用された database の自動復旧は扱わない。復旧方針は database ごとの状態判断を要するため、この原子適用の修正とは分ける。
- migration SQL の分割規則や複数 file 間の atomicity は変えない。今回の保証単位は既存どおり 1 migration file である。
