### PR TITLE
docs(rocketpack): record why root module needs include!/.root.rs

### DIFF
--- a/docs/design/rocketpack-compiler.md
+++ b/docs/design/rocketpack-compiler.md
@@ -195,6 +195,9 @@ package module は内部 source module を非公開で宣言し、型を package
 schema の `use` 文字列を Rust の `use` としてそのまま出力してはならない。
 generator は解決済み symbol owner から local path または external path を選ぶ。
 
+root module `<module_name>.rs` は `include!` で `<module_name>/.root.rs` を取り込み、root package の `pub mod` 宣言は `.root.rs` に置く。
+利用 crate は `<module_name>.rs` を `#[path]` で crate root へ組み込むため、`include!` が取り込んだ先の `pub mod` 宣言のサブモジュール解決基準を `<module_name>/` へ切り替える役割を持つ（§10.1）。
+
 ## 8. 生成物の所有と公開
 
 Rust generator が永続生成物として所有するのは `<output_dir>/<module_name>.rs` と `<output_dir>/<module_name>/` だけである。
@@ -290,6 +293,22 @@ schema symbol と Rust path を一対一にし、同じ package を複数 RPF �
 **却下案**
 RPF ごとの `targets[].dir` と inline `pub mod` は、利用 crate 内で実際に組み込まれる module root を generator が保証できないため採用しない。
 `mod.rs` 形式は有効だが、同名ファイルが増え、Rust 公式が新しい命名規則を推奨しているため採用しない。
+
+<a id="decision-include-root-resolution"></a>
+#### `include!` で root module のサブモジュール解決基準を固定する
+
+**決定**
+root module `<module_name>.rs` は `include!("<module_name>/.root.rs")` だけを持ち、root package の `pub mod` 宣言を `<module_name>/.root.rs` へ置く。
+
+**理由**
+利用 crate は `<module_name>.rs` を `#[path]` で crate root へ組み込む。
+`#[path]` で組み込んだ module が直接 `pub mod <package>;` を宣言すると、rustc はサブモジュールを `#[path]` ファイルの親 directory 基準で解決し、`<output_dir>/<package>.rs` を探して E0583 になる。
+`include!` で `<module_name>/.root.rs` を取り込むと、その中の `pub mod` 宣言の解決基準が `<module_name>/` に切り替わり、`<module_name>/<package>.rs` へ正しく解決する。
+同名ファイル規則（§7）を維持したまま、この解決基準のずれを `include!` で吸収する。
+
+**却下案**
+`<module_name>.rs` に直接 `pub mod` を書く単一 file 化は、`#[path]` でのサブモジュール解決基準が `<output_dir>/` にずれてビルドが壊れるため採用しない。
+`<module_name>/mod.rs` 形式への移行は解決基準問題を解くが、同名ファイル規則を捨てて利用 crate 側の `#[path]` を `mod.rs` へ変える必要があり、代償が大きいため採用しない。
 
 <a id="decision-language-mapping"></a>
 #### 外部名前空間を generator option で割り当てる


### PR DESCRIPTION
## 概要

生成される root module `<module_name>.rs` が `include!` で `<module_name>/.root.rs` を取り込む構成について、その技術的必要性を設計文書へ記録する。

## 背景

`rocketpack.rs` と `.root.rs` の二段構えは一見不要に見える（`rocketpack.rs` に直接 `pub mod` を書けば済むように思える）。しかし実際に統合を試みるとビルドが壊れることが判明したため、現状維持とし、理由を文書化した。

## 技術的理由

利用 crate は生成物を `#[path]` で crate root へ組み込む。

```rust
#[path = "../gen/src/rocketpack.rs"]
pub mod rocketpack;
```

この構成で `rocketpack.rs` に直接 `pub mod omnius;` を書くと、rustc はサブモジュールを `#[path]` ファイルの親ディレクトリ基準（`gen/src/`）で解決し、`gen/src/omnius.rs` を探して E0583 で失敗する。

`include!("rocketpack/.root.rs")` で取り込むと、その中の `pub mod` 宣言の解決基準が `gen/src/rocketpack/` に切り替わり、`gen/src/rocketpack/omnius.rs` へ正しく解決する。同名ファイル規則（`<module_name>.rs` + 同名ディレクトリ）を維持したまま、この解決基準のずれを `include!` で吸収している。

## 変更内容

`docs/design/rocketpack-compiler.md` に以下を追記。

- **§7 Rust module tree**: `include!` と `.root.rs` の事実と、サブモジュール解決基準を切り替える役割を記述
- **§10.1 設計判断**: 「`include!` で root module のサブモジュール解決基準を固定する」を決定・理由・却下案で追加
  - 却下案1: 単一ファイル化（実際に試して E0583 で壊れることを確認）
  - 却下案2: `mod.rs` 形式への移行（解決基準問題は解けるが同名ファイル規則を捨てて利用 crate 側の `#[path]` 変更が必要）

## 検証

- design-docs-writing スキルの規範に従い、strict read-only verifier で独立検証（pass）
- 機械検査クリア（ダッシュ・行番号リンク・1行2句点・保留の条件）