### PR TITLE
fix(rocketpack): restore Eq/Hash derives on OmniHash and OmniCert

### DIFF
--- a/modules/omnikit/rpfs/omni_hash.rpf
+++ b/modules/omnikit/rpfs/omni_hash.rpf
@@ -1,11 +1,13 @@
 version 1;
 package omni_hash;
 
+#[rust::derive(Eq, Hash)]
 enum OmniHashAlgorithmType {
   @1 None;
   @2 Sha3_256;
 }
 
+#[rust::derive(Eq, Hash)]
 struct OmniHash {
   @1 typ: OmniHashAlgorithmType;
   @2 value: bytes[..=MAX_HASH_LENGTH];

--- a/modules/omnikit/rpfs/omni_sign.rpf
+++ b/modules/omnikit/rpfs/omni_sign.rpf
@@ -1,6 +1,7 @@
 version 1;
 package omni_sign;
 
+#[rust::derive(Eq)]
 enum OmniSignType {
   @1 None;
   @2 Ed25519_Sha3_256_Base64Url;
@@ -12,6 +13,7 @@ struct OmniSigner {
   @3 key: bytes[..=MAX_KEY_LENGTH];
 }
 
+#[rust::derive(Eq)]
 struct OmniCert {
   @1 typ: OmniSignType;
   @2 name: string[..=MAX_NAME_LENGTH];

--- a/modules/omnikit/src/generated/omni_hash/__rpf_omni_hash_71c1c2d730c238a0.rs
+++ b/modules/omnikit/src/generated/omni_hash/__rpf_omni_hash_71c1c2d730c238a0.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(nonstandard_style)]
 #![allow(clippy::all)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum OmniHashAlgorithmType {
     None,
     Sha3_256,
@@ -72,7 +72,7 @@ impl omnius_core_rocketpack::RocketPackStruct for OmniHashAlgorithmType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OmniHash {
     pub typ: crate::generated::omni_hash::OmniHashAlgorithmType,
     pub value: Vec<u8>,

--- a/modules/omnikit/src/generated/omni_sign/__rpf_omni_sign_82aa29df59d9d309.rs
+++ b/modules/omnikit/src/generated/omni_sign/__rpf_omni_sign_82aa29df59d9d309.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(nonstandard_style)]
 #![allow(clippy::all)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OmniSignType {
     None,
     Ed25519_Sha3_256_Base64Url,
@@ -137,7 +137,7 @@ impl omnius_core_rocketpack::RocketPackStruct for OmniSigner {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OmniCert {
     pub typ: crate::generated::omni_sign::OmniSignType,
     pub name: String,


### PR DESCRIPTION
## 背景

PR #182（rocketpack compiler rewrite）で、手書きだった `OmniHash` と `OmniCert` を rocketpack 生成型へ移行した。
手書き型は `#[derive(..., Eq, Hash)]`（`OmniHash`）と `#[derive(..., Eq)]`（`OmniCert`）を持っていたが、生成型はデフォルト derive の `Debug, Clone, PartialEq` だけになり、`Eq` と `Hash` が落ちた。

axus daemon 側は `OmniHash` を `HashMap` のキーや `#[derive(Hash, Eq)]` 構造体のフィールドに使っており、core-rs の bump 単体ではコンパイルエラーになる。

## 概要

`omni_hash.rpf` と `omni_sign.rpf` に `#[rust::derive(...)]` 属性を追加し、生成型へ `Eq`/`Hash` を復元した。

## 変更内容

rocketpack codegen は `#[rust::derive(...)]` でデフォルト derive へ追加指定できる仕組み（allowlist: `Eq, Hash, Ord, ...`）を持つ。これを次の型へ適用し、生成コードを再生成した。

- `OmniHash` と `OmniHashAlgorithmType`（omni_hash.rpf）: `#[rust::derive(Eq, Hash)]`
  - `OmniHash` の `Hash` はフィールド型 `OmniHashAlgorithmType` も `Hash` を持つ必要があるため、enum 側にも付ける
- `OmniCert` と `OmniSignType`（omni_sign.rpf）: `#[rust::derive(Eq)]`
  - `OmniCert` の `Eq` はフィールド型 `OmniSignType` も `Eq` を持つ必要があるため、enum 側にも付ける

`OmniSigner` は現状 `Eq`/`Hash` を要求する使われ方をしていないため変更しない。
生成コードの差分は各型の derive 行のみで、ハッシュ付きファイル名や他の生成ファイルは変わらない。

## 影響範囲

公開型の trait 実装が増えるだけ（`PartialEq` に加え `Eq`/`Hash`）で、後方互換性は保たれる。
wire format、エンコード、デコードは変わらない。

## 検証

- [x] `cargo check -p omnius-core-omnikit --all-targets`：通過
- [x] `cargo fmt --all -- --check`：通過
- [x] `cargo test -p omnius-core-omnikit -p omnius-core-rocketpack-compiler --features stable-test`：43 passed, 0 failed

## レビュー観点

- `Eq`/`Hash` を付ける型の範囲が、利用側の要求を満たす最小セットになっているか
- フィールド型の trait 依存（`OmniHash` の `Hash` が `OmniHashAlgorithmType` の `Hash` に依存するなど）を漏れなく満たしているか
