### PR TITLE
build(deps): refresh Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.10.2",
+ "rand",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1583,7 +1583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.10.2",
+ "rand",
  "web-time",
 ]
 
@@ -2809,7 +2809,7 @@ dependencies = [
  "chrono",
  "hex",
  "parking_lot",
- "rand 0.10.2",
+ "rand",
  "serde",
  "tempfile",
  "testresult",
@@ -2891,7 +2891,7 @@ dependencies = [
  "omnius-core-base",
  "omnius-core-rocketpack",
  "parking_lot",
- "rand 0.10.2",
+ "rand",
  "rand_core 0.10.1",
  "sha3",
  "testresult",
@@ -3216,7 +3216,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.10.2",
+ "rand",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -3247,15 +3247,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "prettyplease"
@@ -3347,7 +3338,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.1",
  "lru-slab",
- "rand 0.10.1",
+ "rand",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -3391,16 +3382,6 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -3411,31 +3392,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -4285,7 +4247,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.10.2",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4665,7 +4627,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.2",
+ "rand",
  "socket2",
  "tokio",
  "tokio-util",
@@ -5776,26 +5738,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

現在の `Cargo.toml` 群に対する `Cargo.lock` を再解決すると、参照されなくなった `rand 0.9` 系とその推移依存が残っていた。マニフェストの意図とロックファイルの解決結果を一致させる。

## 概要

`Cargo.lock` を現行の依存グラフに合わせて更新し、不要なパッケージ記録と不要なバージョン指定を除去した。

## 変更内容

依存パッケージのバージョン指定は変更せず、解決結果から到達不能な `rand 0.9`、`rand_chacha 0.9`、`rand_core 0.9`、およびそれらだけが利用していた推移依存を削除した。残る `rand 0.10.2` だけを参照する依存辺は Cargo の通常表記に正規化した。

## 影響範囲

公開 API、設定、保存形式、CLI 引数は変更しない。ビルド時の解決グラフから未使用の推移依存が除かれるが、利用中の依存パッケージのバージョンは維持される。

## 検証

- [x] `env -u RUSTC_WRAPPER cargo metadata --locked --format-version 1 --no-deps`：ロックファイルを変更せず成功
- [x] `env -u RUSTC_WRAPPER cargo check --workspace --locked`：成功
- [x] `git diff --check origin/main...HEAD`：空白エラーなし

## レビュー観点

- `Cargo.lock` の削除対象が現在の依存グラフから到達不能な推移依存だけであり、意図したパッケージ更新を含まないこと
