### PR TITLE
feat: add the shared Rust coding convention and its checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+Rust を変更する前に [docs/coding/rust.md](./docs/coding/rust.md) を読む。
+本書は omnius-labs の Rust リポジトリが共有する規約の正本であり、2 章から 4 章を変更する場合は pxna と axus も同時に更新する。
+
+検証は次のコマンドで実行する。
+
+```sh
+cargo make lint
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -1540,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1927,6 +1927,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2343,13 +2349,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2700,7 +2707,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2857,6 +2864,18 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "omnius-core-lint-style"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "serde",
+ "syn 2.0.117",
+ "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -3362,7 +3381,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3585,7 +3604,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,7 +3663,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3834,6 +3853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,7 +3884,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde_core",
@@ -3883,7 +3911,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde",
@@ -4140,7 +4168,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "log",
  "memchr",
  "percent-encoding",
@@ -4415,7 +4443,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4425,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4674,6 +4702,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap 2.14.1",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tonic"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,7 +4790,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5152,7 +5219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5178,7 +5245,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "semver",
 ]
 
@@ -5255,7 +5322,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5572,6 +5639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,7 +5681,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5639,7 +5712,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "log",
  "serde",
  "serde_derive",
@@ -5658,7 +5731,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.10.0",
+ "indexmap 2.14.1",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "modules/testkit",
   "modules/yamux",
   "entrypoints/rocketpack-compiler",
+  "entrypoints/lint-style",
 ]
 exclude = ["entrypoints/rocketpack-compiled-example"]
 resolver = "3"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,9 +21,14 @@ dependencies = ["install-cargo-audit"]
 command = "cargo"
 args = ["audit", "fix"]
 
+[tasks.lint-style]
+workspace = false
+command = "cargo"
+args = ["run", "--quiet", "--package", "omnius-core-lint-style"]
+
 [tasks.lint]
 workspace = false
-dependencies = ["fmt-check", "clippy"]
+dependencies = ["fmt-check", "clippy", "lint-style"]
 
 [tasks.test]
 command = "cargo"

--- a/docs/coding/rust.md
+++ b/docs/coding/rust.md
@@ -1,0 +1,172 @@
+# Rust コーディング規約
+
+## 1. 本書の役割
+
+本書は、core-rs の手書き Rust コードで責務をどこへ置くかを定める。
+想定読者は、このリポジトリの Rust を変更する開発者と AI エージェントである。
+
+rustfmt が整形を、clippy が一般的な誤りを検査する。
+本書は、それらが判定しない型、関数、module の責務境界だけを扱う。
+
+本書は omnius-labs の Rust リポジトリが共有する規約であり、正本は core-rs の `docs/coding/rust.md` である。
+2 章から 4 章は pxna と axus でも同一に保ち、変更する場合は 3 つのリポジトリを同時に更新する。
+1 章と 5 章は、適用範囲と検査コマンドがリポジトリごとに異なる。
+
+### 1.1 文書間の責務分担
+
+| 文書                      | 受け持つもの                                          |
+| ------------------------- | ----------------------------------------------------- |
+| 本書                      | Rust における責務の置き場所、自由関数の例外、検査方法 |
+| [DESIGN.md](../DESIGN.md) | 機能の設計、不変条件、採用理由                        |
+| [ISSUES.md](../ISSUES.md) | コードで確認した明確な不具合                          |
+
+型が何を担当するかは設計文書が定める。
+本書は、その責務を Rust の型、関数、module へどう配置するかを定める。
+
+### 1.2 適用範囲
+
+規約と `cargo make lint-style` の対象は、リポジトリ直下の `lint-style.toml` が定める。
+core-rs では、`modules/` 配下の手書き crate を対象とする。
+
+次のコードは対象外とする。
+
+| 対象外                          | 理由                                                 |
+| ------------------------------- | ---------------------------------------------------- |
+| `entrypoints`                   | 規約を段階的に導入するため、現時点では対象に含めない |
+| `modules/omnikit/src/generated` | RocketPack の生成物である                            |
+| `target` と `.git`              | build 生成物と version 管理の内部である              |
+| `#[cfg(test)]` 配下と test 関数 | テストの構造は本書で制約しない                       |
+| `fn main`                       | 言語が要求する entrypoint である                     |
+
+## 2. 振る舞いの所有者
+
+### 2.1 自然な所有者を優先する
+
+入力や結果を表す型、状態を持つ型、外部形式を解釈する adapter がある処理は、その型の `impl` に置く。
+呼び出し元が関数名と引数だけから状態と入力を見分ける必要がなくなり、変更の影響範囲も型へ閉じるためである。
+
+```rust
+// 避ける形
+fn detect_format(head: &[u8]) -> Result<ArchiveFormat> { ... }
+
+// 所有者が明確な形
+impl ArchiveFormat {
+    fn detect(head: &[u8]) -> Result<Self> { ... }
+}
+```
+
+自由関数を型へ移すためだけに、意味のない型を作る必要はない。
+次の処理は、自然な所有者を持たない場合に自由関数としてよい。
+
+- 複数の対等な型から使う、状態を持たない低レベルのアルゴリズム
+- OS API や FFI を包む platform 境界
+- framework が関数を要求する callback
+
+本番コードへ自由関数を置く場合は、4 章の marker で理由をコードの隣に残す。
+
+### 2.2 unit struct と self なし関連関数
+
+フィールドを持たない型は、型名が一つの役割を表す場合に使える。
+stateless な trait 実装、parser、migrator、converter がこの形に該当する。
+
+```rust
+struct ElementParser;
+
+impl ElementParser {
+    fn parse_tcp_ip(element: &Element) -> Result<SocketAddr> { ... }
+}
+```
+
+unit struct を自由関数の退避先として使うわけではない。
+`Util`、`Helpers`、`Functions` のように、どの処理でも入れられる名前の型は作らない。
+
+self を取らない関連関数は、`Self` を返す constructor だけに限定しない。
+その型が表す役割に操作群が収まり、別の責務を追加する場所になっていなければよい。
+
+### 2.3 一つのファイルは一つの概念を扱う
+
+ファイルは、型の個数ではなく責務のまとまりで分ける。
+主型、その trait 実装、専用の入力型や出力型、fake は同居させてよい。
+
+`clock.rs` に実装と fake を置く形や、`timestamp.rs` に同じ表現の複数精度を置く形は、一つの概念に収まる。
+一方、`util.rs` や `helpers.rs` に関係の薄い処理を集めたり、`extract.rs` のように処理段階だけを名前にして関数を置いたりしない。
+
+ファイル名から、そのファイルが所有する概念を説明できる状態を保つ。
+
+## 3. 型が保持するもの
+
+### 3.1 依存は寿命で分ける
+
+構築後も同じ相手を使い続ける場合、その依存を constructor で受け取り、フィールドに保持する。
+メソッド引数には、呼び出すたびに変わる操作入力だけを置く。
+
+generic、trait object、`Arc` のどれを使うかは、共有の要否と動的 dispatch の要否で決める。
+外部境界だからという理由だけで、すべてを `Arc<dyn Trait>` に統一しない。
+
+引数の個数だけでは依存と入力を区別できない。
+引数が増えた場合は、個数を減らす前に各値の寿命を確認する。
+
+### 3.2 エラー変換は文脈の有無で分ける
+
+外部エラーから crate のエラーへの一対一で文脈に依存しない変換は、`From` に置く。
+どこで `?` を使っても同じ `ErrorKind` になる変換だけが該当する。
+
+暗号化、未対応形式、破損のように、呼び出した機能の文脈で分類が変わる変換は、外部形式を所有する adapter や domain type に置く。
+この変換では、可能な限り元の error を source として保持する。
+
+### 3.3 constructor の名前
+
+型を作る標準経路が一つなら、失敗して `Result<Self>` を返す場合も `new` を使える。
+`parse`、`open`、`connect`、`acquire` は、単なる構築ではなく操作の意味を名前に出す場合に使う。
+
+`Default` は、有効な既定値が一つに定まる型だけに実装する。
+必須値を仮の値で埋めるためには使わない。
+
+## 4. 自由関数の marker
+
+### 4.1 恒久的な例外
+
+自然な所有者を持たない本番自由関数には、宣言の直前に `allow` marker を置く。
+理由には、なぜ型の `impl` に属さないのかを書く。
+
+```rust
+// omnius-lint:allow(free-fn) OS ごとの system call を cfg module の境界として公開する
+fn process_exists(pid: u32) -> bool { ... }
+```
+
+### 4.2 未解消の責務配置
+
+自然な所有者があるものの、挙動変更を伴う移動を別の変更へ分ける場合は `debt` marker を置く。
+理由には、移動先となる型または欠けている概念と、今回移動しない理由を書く。
+
+```rust
+// omnius-lint:debt(free-fn) ArchiveExtractor へ移すリファクタを挙動変更と分離する
+fn materialize(...) -> Result<MaterializedFile> { ... }
+```
+
+`debt` は許可ではなく、現在残っている責務配置の負債である。
+新しい変更で `debt` を追加せず、既存の関数を移動または削除したときは marker も削除する。
+この増減は PR の差分レビューで確認する。
+
+### 4.3 marker の検査
+
+marker の理由は必須である。
+未マークの自由関数、不正な marker、空の理由、対応する関数がない marker は `cargo make lint-style` を失敗させる。
+
+検査器は `debt` を表示するが、既存の挙動を保ったまま規約を導入できるよう、`debt` だけでは失敗させない。
+
+unit struct、self なし関連関数、ファイルの概念境界、依存の寿命、エラー変換は意味判断を要するため、レビューで確認する。
+
+検査器の実装は core-rs の `entrypoints/lint-style` にあり、pxna と axus は submodule 経由で同じ bin を使う。
+
+## 5. 検査コマンド
+
+```sh
+cargo make lint-style
+cargo make lint
+```
+
+`cargo make lint-style` は本書の自由関数 marker を検査する。
+`cargo make lint` は rustfmt、clippy、`lint-style` を実行する。
+
+GitHub Actions は `cargo make lint` を lint の入口として使うため、同じ検査が CI でも実行される。

--- a/entrypoints/lint-style/Cargo.toml
+++ b/entrypoints/lint-style/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "omnius-core-lint-style"
+version = "0.1.0"
+edition = "2024"
+authors = ["Lyrise <lyrise1984@gmail.com>"]
+publish = false
+
+[[bin]]
+name = "lint-style"
+path = "src/main.rs"
+
+# 依存は workspace から解決しない。
+# 本 crate は pxna と axus の workspace にも member として取り込まれるため、
+# workspace ごとに version や feature がずれると検査結果が静かに変わる。
+# 特に proc-macro2 の span-locations は、欠けると行番号が 0 になる。
+[dependencies]
+anyhow = "1.0.101"
+proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
+serde = { version = "1.0.228", features = ["derive"] }
+syn = { version = "2.0.117", features = ["full"] }
+toml = "1.0.6"
+walkdir = "2.5.0"

--- a/entrypoints/lint-style/src/checker.rs
+++ b/entrypoints/lint-style/src/checker.rs
@@ -1,0 +1,258 @@
+use std::{
+    collections::BTreeSet,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use proc_macro2::TokenTree;
+use syn::{Attribute, Item, Meta, spanned::Spanned as _};
+use walkdir::WalkDir;
+
+use crate::{
+    config::Config,
+    finding::Finding,
+    marker::{Marker, MarkerKind},
+    source_file::SourceFile,
+};
+
+#[derive(Default)]
+pub struct CheckReport {
+    pub errors: Vec<Finding>,
+    pub debts: Vec<Finding>,
+    pub allow_count: usize,
+}
+
+pub struct Checker {
+    base: PathBuf,
+    config: Config,
+}
+
+impl Checker {
+    pub fn new(base: &Path, config: Config) -> Self {
+        Self { base: base.to_path_buf(), config }
+    }
+
+    pub fn run(self) -> Result<CheckReport> {
+        let mut report = CheckReport::default();
+        let mut walker = WalkDir::new(&self.base).sort_by_file_name().into_iter();
+
+        while let Some(entry) = walker.next() {
+            let entry = entry?;
+            let path = entry.path();
+
+            if entry.file_type().is_dir() {
+                if path != self.base && self.config.is_excluded(path) {
+                    walker.skip_current_dir();
+                }
+                continue;
+            }
+            if !entry.file_type().is_file() || path.extension() != Some(OsStr::new("rs")) {
+                continue;
+            }
+            if self.config.is_excluded(path) {
+                continue;
+            }
+
+            let source = SourceFile::read(path, &self.base)?;
+            Self::check_source(&source, &mut report);
+        }
+
+        Ok(report)
+    }
+
+    fn check_source(source: &SourceFile, report: &mut CheckReport) {
+        let mut consumed_markers = BTreeSet::new();
+        Self::check_items(source, &source.ast().items, false, &mut consumed_markers, report);
+
+        for (line, marker) in source.markers() {
+            if consumed_markers.contains(line) {
+                continue;
+            }
+            let message = match marker {
+                Ok(_) => "marker is not attached to a checked free function".to_string(),
+                Err(error) => format!("invalid omnius-lint marker: {error}"),
+            };
+            report.errors.push(Finding::error(source.display_path().to_path_buf(), *line, message));
+        }
+    }
+
+    fn check_items(source: &SourceFile, items: &[Item], in_test_scope: bool, consumed_markers: &mut BTreeSet<usize>, report: &mut CheckReport) {
+        for item in items {
+            match item {
+                Item::Fn(function) => {
+                    if in_test_scope || attributes_are_test(&function.attrs) || function.sig.ident == "main" {
+                        continue;
+                    }
+                    let line = function.sig.fn_token.span().start().line;
+                    let subject = format!("fn {}", function.sig.ident);
+                    let Some((marker_line, marker)) = source.marker_above(line) else {
+                        report
+                            .errors
+                            .push(Finding::error(source.display_path().to_path_buf(), line, format!("unmarked free function: {subject}")));
+                        continue;
+                    };
+                    consumed_markers.insert(marker_line);
+                    match marker {
+                        Ok(marker) => Self::record_marker(source, line, &subject, marker, report),
+                        Err(error) => report.errors.push(Finding::error(
+                            source.display_path().to_path_buf(),
+                            marker_line,
+                            format!("invalid omnius-lint marker: {error}"),
+                        )),
+                    }
+                }
+                Item::Mod(module) => {
+                    let nested_test_scope = in_test_scope || attributes_are_test(&module.attrs);
+                    if let Some((_, nested_items)) = &module.content {
+                        Self::check_items(source, nested_items, nested_test_scope, consumed_markers, report);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn record_marker(source: &SourceFile, line: usize, subject: &str, marker: &Marker, report: &mut CheckReport) {
+        match marker.kind() {
+            MarkerKind::Allow => report.allow_count += 1,
+            MarkerKind::Debt => report
+                .debts
+                .push(Finding::debt(source.display_path().to_path_buf(), line, format!("{subject} -- {}", marker.reason()))),
+        }
+    }
+}
+
+fn attributes_are_test(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if attr.path().segments.last().is_some_and(|segment| segment.ident == "test") {
+            return true;
+        }
+        let Meta::List(list) = &attr.meta else {
+            return false;
+        };
+        attr.path().is_ident("cfg") && cfg_is_test(list.tokens.clone().into_iter())
+    })
+}
+
+fn cfg_is_test(mut tokens: impl Iterator<Item = TokenTree>) -> bool {
+    matches!(tokens.next(), Some(TokenTree::Ident(ident)) if ident == "test") && tokens.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::source_file::SourceFile;
+
+    use super::{CheckReport, Checker};
+
+    fn check(text: &str) -> CheckReport {
+        let source = SourceFile::for_test(text);
+        let mut report = CheckReport::default();
+        Checker::check_source(&source, &mut report);
+        report
+    }
+
+    #[test]
+    fn accepts_allow_and_reports_debt_without_error() {
+        let report = check(
+            r#"
+// omnius-lint:allow(free-fn) OS boundary
+fn allowed() {}
+
+// omnius-lint:debt(free-fn) move to Owner in a separate refactor
+fn debt() {}
+"#,
+        );
+
+        assert!(report.errors.is_empty());
+        assert_eq!(report.allow_count, 1);
+        assert_eq!(report.debts.len(), 1);
+    }
+
+    #[test]
+    fn reports_the_declaration_line_of_a_finding() {
+        let report = check(
+            r#"
+fn first() {}
+
+fn second() {}
+"#,
+        );
+
+        assert_eq!(report.errors.len(), 2);
+        assert!(report.errors[0].to_string().contains(":2:"));
+        assert!(report.errors[1].to_string().contains(":4:"));
+    }
+
+    #[test]
+    fn rejects_unmarked_function() {
+        let report = check("fn helper() {}");
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].message().contains("unmarked free function"));
+    }
+
+    #[test]
+    fn rejects_invalid_marker_without_duplicate_unmarked_error() {
+        let report = check(
+            r#"
+// omnius-lint:allow(unknown) reason
+fn helper() {}
+"#,
+        );
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].message().contains("unknown marker key"));
+    }
+
+    #[test]
+    fn rejects_unused_marker() {
+        let report = check("// omnius-lint:allow(free-fn) no function follows");
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].message().contains("not attached"));
+    }
+
+    #[test]
+    fn excludes_main_and_test_functions() {
+        let report = check(
+            r#"
+fn main() {}
+
+#[test]
+fn unit_test() {}
+
+#[cfg(test)]
+fn cfg_test() {}
+"#,
+        );
+        assert!(report.errors.is_empty());
+    }
+
+    #[test]
+    fn checks_functions_that_are_not_test_only() {
+        let report = check(
+            r#"
+#[cfg(not(test))]
+fn helper() {}
+"#,
+        );
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].message().contains("fn helper"));
+    }
+
+    #[test]
+    fn checks_inline_modules_but_excludes_inline_test_modules() {
+        let report = check(
+            r#"
+mod checked {
+    fn helper() {}
+}
+
+#[cfg(test)]
+mod tests {
+    fn helper() {}
+}
+"#,
+        );
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].message().contains("fn helper"));
+    }
+}

--- a/entrypoints/lint-style/src/config.rs
+++ b/entrypoints/lint-style/src/config.rs
@@ -1,0 +1,85 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result};
+use serde::Deserialize;
+
+/// 走査の起点に置く設定ファイルの名前。
+const FILE_NAME: &str = "lint-style.toml";
+
+/// 名前だけで走査から外すディレクトリ。
+/// build 生成物と version 管理の内部は、どの repository でも検査対象にならない。
+const IGNORED_DIR_NAMES: [&str; 2] = ["target", ".git"];
+
+/// `lint-style.toml` の外部形式。
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigFile {
+    #[serde(default)]
+    exclude: Vec<PathBuf>,
+}
+
+pub struct Config {
+    excludes: Vec<PathBuf>,
+}
+
+impl Config {
+    pub fn load(base: &Path) -> Result<Self> {
+        let path = base.join(FILE_NAME);
+        let text = fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+        let file: ConfigFile = toml::from_str(&text).with_context(|| format!("failed to parse {}", path.display()))?;
+
+        Ok(Self {
+            excludes: file.exclude.iter().map(|relative| base.join(relative)).collect(),
+        })
+    }
+
+    pub fn is_excluded(&self, path: &Path) -> bool {
+        if path.file_name().is_some_and(|name| IGNORED_DIR_NAMES.iter().any(|ignored| name == *ignored)) {
+            return true;
+        }
+        self.excludes.iter().any(|excluded| path.starts_with(excluded))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::Config;
+
+    fn config(excludes: &[&str]) -> Config {
+        Config {
+            excludes: excludes.iter().map(|excluded| Path::new("/repo").join(excluded)).collect(),
+        }
+    }
+
+    #[test]
+    fn excludes_configured_paths_and_their_contents() {
+        let config = config(&["refs", "entrypoints/interface"]);
+
+        assert!(config.is_excluded(&PathBuf::from("/repo/refs")));
+        assert!(config.is_excluded(&PathBuf::from("/repo/refs/core-rs/modules/base/src/lib.rs")));
+        assert!(config.is_excluded(&PathBuf::from("/repo/entrypoints/interface/src/models.rs")));
+        assert!(!config.is_excluded(&PathBuf::from("/repo/entrypoints/daemon/src/main.rs")));
+    }
+
+    #[test]
+    fn excludes_ignored_directory_names_anywhere() {
+        let config = config(&[]);
+
+        assert!(config.is_excluded(&PathBuf::from("/repo/target")));
+        assert!(config.is_excluded(&PathBuf::from("/repo/modules/engine/target")));
+        assert!(config.is_excluded(&PathBuf::from("/repo/.git")));
+        assert!(!config.is_excluded(&PathBuf::from("/repo/modules/engine/src")));
+    }
+
+    #[test]
+    fn does_not_exclude_paths_that_only_share_a_name_prefix() {
+        let config = config(&["refs"]);
+
+        assert!(!config.is_excluded(&PathBuf::from("/repo/refs-extra/src/lib.rs")));
+    }
+}

--- a/entrypoints/lint-style/src/finding.rs
+++ b/entrypoints/lint-style/src/finding.rs
@@ -1,0 +1,52 @@
+use std::{fmt, path::PathBuf};
+
+pub struct Finding {
+    path: PathBuf,
+    line: usize,
+    level: Level,
+    message: String,
+}
+
+impl Finding {
+    pub fn error(path: PathBuf, line: usize, message: impl Into<String>) -> Self {
+        Self::new(path, line, Level::Error, message)
+    }
+
+    pub fn debt(path: PathBuf, line: usize, message: impl Into<String>) -> Self {
+        Self::new(path, line, Level::Debt, message)
+    }
+
+    fn new(path: PathBuf, line: usize, level: Level, message: impl Into<String>) -> Self {
+        Self {
+            path,
+            line,
+            level,
+            message: message.into(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for Finding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}: [{}] {}", self.path.display(), self.line, self.level.as_str(), self.message)
+    }
+}
+
+enum Level {
+    Error,
+    Debt,
+}
+
+impl Level {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Debt => "debt",
+        }
+    }
+}

--- a/entrypoints/lint-style/src/main.rs
+++ b/entrypoints/lint-style/src/main.rs
@@ -1,0 +1,62 @@
+//! `docs/coding/rust.md` の自由関数 marker を検査する。
+//!
+//! 走査の起点は process の current directory であり、そこに置かれた
+//! `lint-style.toml` が検査対象から外す path を決める。
+//! omnius-labs の Rust repository は、この bin を共有して同じ規約を検査する。
+
+mod checker;
+mod config;
+mod finding;
+mod marker;
+mod source_file;
+
+use std::{env, process::ExitCode};
+
+use crate::{checker::Checker, config::Config};
+
+fn main() -> ExitCode {
+    let base = match env::current_dir() {
+        Ok(base) => base,
+        Err(error) => {
+            eprintln!("lint-style: failed to resolve the current directory: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let config = match Config::load(&base) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("lint-style: {error:#}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let report = match Checker::new(&base, config).run() {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("lint-style: {error:#}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    for debt in &report.debts {
+        println!("{debt}");
+    }
+    for error in &report.errors {
+        println!("{error}");
+    }
+
+    if report.errors.is_empty() {
+        println!("lint-style: ok ({} allow, {} debt)", report.allow_count, report.debts.len());
+        ExitCode::SUCCESS
+    } else {
+        println!();
+        println!(
+            "lint-style: {} error(s), {} allow, {} debt. see docs/coding/rust.md",
+            report.errors.len(),
+            report.allow_count,
+            report.debts.len()
+        );
+        ExitCode::FAILURE
+    }
+}

--- a/entrypoints/lint-style/src/marker.rs
+++ b/entrypoints/lint-style/src/marker.rs
@@ -1,0 +1,96 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MarkerKind {
+    Allow,
+    Debt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Marker {
+    kind: MarkerKind,
+    reason: String,
+}
+
+impl Marker {
+    pub fn parse(line: &str) -> Option<Result<Self, String>> {
+        let comment = line.trim().strip_prefix("//")?.trim_start();
+        let rest = comment.strip_prefix("omnius-lint:")?;
+        Some(Self::parse_body(rest))
+    }
+
+    fn parse_body(body: &str) -> Result<Self, String> {
+        let Some(open) = body.find('(') else {
+            return Err("marker must use allow(free-fn) or debt(free-fn)".to_string());
+        };
+        let Some(close_offset) = body[open + 1..].find(')') else {
+            return Err("marker is missing ')'".to_string());
+        };
+        let close = open + 1 + close_offset;
+        let kind = match &body[..open] {
+            "allow" => MarkerKind::Allow,
+            "debt" => MarkerKind::Debt,
+            other => return Err(format!("unknown marker kind '{other}'")),
+        };
+        let key = &body[open + 1..close];
+        if key != "free-fn" {
+            return Err(format!("unknown marker key '{key}'"));
+        }
+
+        let suffix = &body[close + 1..];
+        if !suffix.is_empty() && !suffix.starts_with(char::is_whitespace) {
+            return Err("marker reason must be separated by whitespace".to_string());
+        }
+        let reason = suffix.trim();
+        if reason.is_empty() {
+            return Err("marker reason is required".to_string());
+        }
+
+        Ok(Self { kind, reason: reason.to_string() })
+    }
+
+    pub fn kind(&self) -> MarkerKind {
+        self.kind
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Marker, MarkerKind};
+
+    #[test]
+    fn parses_allow_and_debt() {
+        let allow = Marker::parse("// omnius-lint:allow(free-fn) OS boundary").expect("marker").expect("valid marker");
+        assert_eq!(allow.kind(), MarkerKind::Allow);
+        assert_eq!(allow.reason(), "OS boundary");
+
+        let debt = Marker::parse("  // omnius-lint:debt(free-fn) move to ArchiveFormat")
+            .expect("marker")
+            .expect("valid marker");
+        assert_eq!(debt.kind(), MarkerKind::Debt);
+        assert_eq!(debt.reason(), "move to ArchiveFormat");
+    }
+
+    #[test]
+    fn rejects_missing_reason() {
+        let error = Marker::parse("// omnius-lint:allow(free-fn)").expect("marker").expect_err("reason must be required");
+        assert_eq!(error, "marker reason is required");
+    }
+
+    #[test]
+    fn rejects_unknown_kind_and_key() {
+        let kind_error = Marker::parse("// omnius-lint:waive(free-fn) reason").expect("marker").expect_err("kind must be checked");
+        assert_eq!(kind_error, "unknown marker kind 'waive'");
+
+        let key_error = Marker::parse("// omnius-lint:allow(unit-struct) reason").expect("marker").expect_err("key must be checked");
+        assert_eq!(key_error, "unknown marker key 'unit-struct'");
+    }
+
+    #[test]
+    fn rejects_malformed_marker() {
+        let error = Marker::parse("// omnius-lint:allow free-fn").expect("marker").expect_err("syntax must be checked");
+        assert_eq!(error, "marker must use allow(free-fn) or debt(free-fn)");
+    }
+}

--- a/entrypoints/lint-style/src/source_file.rs
+++ b/entrypoints/lint-style/src/source_file.rs
@@ -1,0 +1,71 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result};
+
+use crate::marker::Marker;
+
+pub struct SourceFile {
+    display_path: PathBuf,
+    lines: Vec<String>,
+    ast: syn::File,
+    markers: BTreeMap<usize, Result<Marker, String>>,
+}
+
+impl SourceFile {
+    pub fn read(path: &Path, base: &Path) -> Result<Self> {
+        let text = fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+        let display_path = path.strip_prefix(base).unwrap_or(path);
+        Self::parse(display_path, &text)
+    }
+
+    fn parse(display_path: &Path, text: &str) -> Result<Self> {
+        let ast = syn::parse_file(text).with_context(|| format!("failed to parse {}", display_path.display()))?;
+        let lines: Vec<String> = text.lines().map(str::to_string).collect();
+        let markers = lines
+            .iter()
+            .enumerate()
+            .filter_map(|(index, line)| Marker::parse(line).map(|marker| (index + 1, marker)))
+            .collect();
+
+        Ok(Self {
+            display_path: display_path.to_path_buf(),
+            lines,
+            ast,
+            markers,
+        })
+    }
+
+    pub fn ast(&self) -> &syn::File {
+        &self.ast
+    }
+
+    pub fn display_path(&self) -> &Path {
+        &self.display_path
+    }
+
+    pub fn markers(&self) -> &BTreeMap<usize, Result<Marker, String>> {
+        &self.markers
+    }
+
+    pub fn marker_above(&self, line: usize) -> Option<(usize, &Result<Marker, String>)> {
+        let mut index = line.checked_sub(1)?;
+        while index > 0 {
+            let trimmed = self.lines.get(index - 1)?.trim();
+            if trimmed.is_empty() || trimmed.starts_with("#[") || trimmed.starts_with("#![") || trimmed.starts_with("///") || trimmed.starts_with("//!") {
+                index -= 1;
+                continue;
+            }
+            return self.markers.get(&index).map(|marker| (index, marker));
+        }
+        None
+    }
+
+    #[cfg(test)]
+    pub fn for_test(text: &str) -> Self {
+        Self::parse(Path::new("test.rs"), text).expect("test source must parse")
+    }
+}

--- a/lint-style.toml
+++ b/lint-style.toml
@@ -1,0 +1,5 @@
+# 検査対象から外す path。docs/coding/rust.md の「1.2 適用範囲」の表と対応する。
+exclude = [
+  "entrypoints",
+  "modules/omnikit/src/generated",
+]

--- a/modules/base/src/serde/base64.rs
+++ b/modules/base/src/serde/base64.rs
@@ -1,11 +1,13 @@
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+// omnius-lint:allow(free-fn) serde の with attribute が module 直下の serialize を要求する
 pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
     let base64 = BASE64.encode(v);
     String::serialize(&base64, s)
 }
 
+// omnius-lint:allow(free-fn) serde の with attribute が module 直下の deserialize を要求する
 pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
     let base64 = String::deserialize(d)?;
     BASE64.decode(base64.as_bytes()).map_err(serde::de::Error::custom)

--- a/modules/omnikit/src/service/connection/secure/auth.rs
+++ b/modules/omnikit/src/service/connection/secure/auth.rs
@@ -193,6 +193,7 @@ where
     }
 }
 
+// omnius-lint:debt(free-fn) Authenticator の署名 preimage を組み立てる関連関数へ移す変更を、署名の検証と分ける
 fn auth_type_tag(value: &AuthType) -> u32 {
     match value {
         AuthType::None => 1,
@@ -200,6 +201,7 @@ fn auth_type_tag(value: &AuthType) -> u32 {
     }
 }
 
+// omnius-lint:debt(free-fn) Authenticator の署名 preimage を組み立てる関連関数へ移す変更を、署名の検証と分ける
 fn agreement_type_tag(value: &OmniAgreementAlgorithmType) -> u32 {
     match value {
         OmniAgreementAlgorithmType::None => 1,
@@ -207,6 +209,7 @@ fn agreement_type_tag(value: &OmniAgreementAlgorithmType) -> u32 {
     }
 }
 
+// omnius-lint:debt(free-fn) algorithm type flags を表す型が欠けており、型の新設を暗号処理の変更と分ける
 const fn has_flag(flags: u32, flag: u32) -> bool {
     flags & flag != 0
 }

--- a/modules/omnikit/src/service/connection/secure/util.rs
+++ b/modules/omnikit/src/service/connection/secure/util.rs
@@ -1,3 +1,4 @@
+// omnius-lint:debt(free-fn) nonce を表す型が欠けており、Aes256GcmEncoder と Aes256GcmDecoder が共有する所有者の新設を暗号処理の変更と分ける
 pub fn increment_bytes(bytes: &mut [u8]) {
     for b in bytes {
         if *b == 0xFF {

--- a/modules/rocketpack/src/rocket_pack_encoder.rs
+++ b/modules/rocketpack/src/rocket_pack_encoder.rs
@@ -18,6 +18,7 @@ pub enum RocketPackEncoderError {
     LengthOutOfRange { context: &'static str, min: u64, max: u64, actual: u64 },
 }
 
+// omnius-lint:debt(free-fn) RocketPack の生成コードが crate 直下の関数として呼ぶため、移動には compiler の codegen 変更と再生成が要る
 pub fn validate_length(context: &'static str, min: u64, max: u64, actual: usize) -> Result<()> {
     let actual = u64::try_from(actual).map_err(|_| RocketPackEncoderError::LengthOverflow { len: actual })?;
     if actual < min || actual > max {


### PR DESCRIPTION
## 背景

Rust の責務配置を定めた規約と、自由関数（型の `impl` に属さない module 直下の関数）に marker を要求する検査器は pxna にしかなく、対象ディレクトリと marker prefix が pxna 専用に固定されていた。
同じ規約を axus と core-rs へ広げるにあたり、検査器を 3 リポジトリで別々に持つことは避けたい。
core-rs は pxna と axus の両方が submodule として参照しているため、共有物の置き場所になる。

既存の自由関数を型へ移す作業は含めない。
規約の導入と挙動を変えるリファクタを分けるためであり、移動先は `debt` marker に記録している。
3 リポジトリの規約文書が同一であり続けることを機械的に保証する仕組みはなく、`AGENTS.md` の「3 リポジトリを同時に更新する」という取り決めに委ねている。

## 概要

検査器を `entrypoints/lint-style` に共有 bin として置き、走査の起点にある `lint-style.toml` が対象を決める。
規約文書の正本は core-rs に置き、pxna と axus はその複製を持つ。

## 変更内容

### 規約文書

`docs/coding/rust.md` を 3 リポジトリで共有する規約の正本とする。
2 章から 4 章はバイト単位で一致させ、1 章の適用範囲と 5 章の検査コマンドだけをリポジトリごとに差し替える。
`AGENTS.md` には、Rust を変更する前に規約を読むことと、2 章から 4 章の変更時に 3 リポジトリを同時に更新することを書いた。

### 検査器

対象は `lint-style.toml` の `exclude` で決める。
除外を列挙する形にしたのは、新しい crate を足したときに黙って検査対象から外れる事故を防ぐためである。
marker の prefix は 3 リポジトリ共通の `omnius-lint:` とし、コードをリポジトリ間で移しても marker が生きるようにした。

依存は workspace ではなく crate 内で固定した。
この crate は pxna と axus の workspace にも member として取り込まれ、`workspace = true` では消費側の `workspace.dependencies` で解決されるためである。
とくに `proc-macro2` の `span-locations` は、欠けてもコンパイルが通り、行番号が 0 になるだけで結果が静かに壊れる。
この feature が効いていることは、宣言行を検査する unit test で押さえた。

### 適用範囲と既存コード

対象は `modules/` に限り、`entrypoints` は規約 1.2 の表に理由を書いたうえで対象外にした。
`entrypoints/rocketpack-compiler` には自由関数が約 105 個あり、そのすべてに理由を書くことは規約の導入とは別の作業になる。

`modules/` の 7 個には marker を付けた。
`allow` 2 個は serde の `with` attribute が module 直下の `serialize` と `deserialize` を要求するもの、`debt` 5 個は `Authenticator` の関連関数へ移すもの 2 個と、flags および nonce を表す型が欠けているもの、生成コードが crate 直下の関数として呼ぶ `validate_length` である。
`debt` は許可ではなく責務配置の負債であり、検査器は表示するが失敗させない。

## 影響範囲

- `cargo make lint` に `lint-style` が加わる。CI は `cargo make lint` を入口に使うため workflow の変更は不要である
- `modules/` の変更は marker コメントの追加だけで、公開 API、wire format、挙動は変わらない
- workspace member として参照する側では `anyhow`、`syn`、`walkdir`、`toml`、`serde` が Cargo.lock に入る
- 今後 `modules/` に自由関数を追加すると、marker を付けるまで `cargo make lint` が失敗する

## 検証

- [x] `cargo make lint`：`lint-style: ok (2 allow, 5 debt)`。fmt-check と clippy も通過
- [x] `cargo test --package omnius-core-lint-style`：15 passed, 0 failed
- [x] pxna から workspace member として参照し `cargo make lint`：`lint-style: ok (9 allow, 0 debt)`。pxna 専用の検査器と同じ結果
- [x] axus から同様に参照し `cargo make lint`：`lint-style: ok (0 allow, 5 debt)`
- [x] GitHub Actions の [test run 33249305659](https://github.com/omnius-labs/core-rs/actions/runs/33249305659)：`cargo make lint` と `cargo test` を Ubuntu、Windows、macOS で実行し、3 環境とも成功

## レビュー観点

- `entrypoints` を対象外にした判断。段階導入として妥当か、`rocketpack-compiler` も今回含めるべきか
- 5 個の `debt` の理由が移動先の型または欠けている概念を正しく指しているか。とくに `validate_length` は生成コードとの契約であり、`allow` とすべきかどうか
- 依存を crate 内で固定した判断。core-rs の他の member crate はすべて `workspace = true` を使っており、この crate だけが例外になる

## 関連

- pxna と axus に本 PR に依存する変更がある。マージ後に両リポジトリの submodule ポインタを main のコミットへ指し直す
